### PR TITLE
HN-45: Add Paging and continuous scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Happy News is a source of positive news. A school project for Fontys Hogeschool 
 
 ## API
 
-#### » `https://happynews-api.svendubbeld.nl/post?ordered={ordered}`
+#### » `https://happynews-api.svendubbeld.nl/post?page={pagenumber}&size={size}`
 
-Retrieves all posts. ordered is not required, and defaults to `true`.
+Retrieves all posts in paginated format. Default page is 0 and default size is 20.
 
 #### » `https://happynews-api.svendubbeld.nl/post/uuid/{uuid}`
 

--- a/android/src/main/java/nl/fhict/happynews/android/LoadListener.java
+++ b/android/src/main/java/nl/fhict/happynews/android/LoadListener.java
@@ -1,0 +1,8 @@
+package nl.fhict.happynews.android;
+
+/**
+ * Created by tom on 03/04/2017.
+ */
+public interface LoadListener {
+    void onFinishedLoading();
+}

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -1,21 +1,17 @@
 package nl.fhict.happynews.android;
 
 import android.content.Context;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import com.koushikdutta.async.future.FutureCallback;
+import com.koushikdutta.ion.Ion;
 import nl.fhict.happynews.android.activity.MainActivity;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
-import com.koushikdutta.ion.Ion;
 import nl.fhict.happynews.android.model.Page;
-import nl.fhict.happynews.android.model.Post;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 /**
  * Created by Sander on 06/03/2017.
@@ -23,15 +19,12 @@ import java.util.List;
 public class PostManager {
 
     private static PostManager ourInstance = new PostManager();
-
     public static PostManager getInstance() {
         return ourInstance;
     }
-
-    private String API_URL = "https://happynews-api.svendubbeld.nl";
+    private static final String API_URL = "https://happynews-api.svendubbeld.nl";
     private FeedAdapter feedAdapter;
-
-    private MainActivity activity;
+    private MainActivity mainActivity;
 
     private PostManager() {}
 
@@ -67,8 +60,8 @@ public class PostManager {
 
                             feedAdapter.addPage(result);
 
-                            if (activity != null){
-                                activity.didFinishLoading(); //Notifiy activity that loading is done
+                            if (mainActivity != null){
+                                mainActivity.didFinishLoading(); //Notifiy mainActivity that loading is done
                             }
                         } else {
                             Log.e("PostManager", "Json Exception: ", e);
@@ -91,6 +84,6 @@ public class PostManager {
      * @param activity
      */
     public void subscribeActivity(MainActivity activity){
-        this.activity = activity;
+        this.mainActivity = activity;
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -23,7 +23,6 @@ public class PostManager {
     }
     private static final String API_URL = "https://happynews-api.svendubbeld.nl";
     private FeedAdapter feedAdapter;
-    private LoadListener listener;
 
     private PostManager() {}
 
@@ -78,11 +77,4 @@ public class PostManager {
         this.feedAdapter = feedAdapter;
     }
 
-    /**
-     * Subscribes a LoadListener to the PostManager to notify when finished loading
-     * @param listener
-     */
-    public void subscribeListener(LoadListener listener){
-        this.listener = listener;
-    }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -1,10 +1,12 @@
 package nl.fhict.happynews.android;
 
 import android.content.Context;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import com.koushikdutta.async.future.FutureCallback;
+import nl.fhict.happynews.android.activity.MainActivity;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
 import com.koushikdutta.ion.Ion;
 import nl.fhict.happynews.android.model.Page;
@@ -26,11 +28,17 @@ public class PostManager {
         return ourInstance;
     }
 
-    private String API_URL = "https://happynews-api.svendubbeld.nl/post";
+    private String API_URL = "https://happynews-api.svendubbeld.nl/";
     private ArrayList<Post> newPosts;
     private FeedAdapter feedAdapter;
 
+    private MainActivity activity;
+
     private PostManager() {}
+
+    public void subscribeActivity(MainActivity activity){
+        this.activity = activity;
+    }
 
     /**
      * Method that updates the feedAdapter with a new list of posts from the api
@@ -52,7 +60,7 @@ public class PostManager {
 
         Ion.getDefault(context).configure().setGson(gson);
         Ion.with(context)
-                .load(API_URL)
+                .load(API_URL + "/post")
                 .as(new TypeToken<List<Post>>() {
                 })
                 .setCallback(new FutureCallback<List<Post>>() {
@@ -83,21 +91,26 @@ public class PostManager {
 
         Ion.getDefault(context).configure().setGson(gson);
         Ion.with(context)
-                .load("http://10.0.2.2:8080/page?page=" + page + "&size=" + size)
+                .load("http://10.0.2.2:8080/postpage?page=" + page + "&size=" + size)
                 .as(new TypeToken<Page>() {
                 })
                 .setCallback(new FutureCallback<Page>() {
                     @Override
                     public void onCompleted(Exception e, Page result) {
                         if (e == null){
-                            //DO SOME SHIT
+                            Log.d("PostManager", "Loaded page: " + result.getNumber());
                             feedAdapter.addPage(result);
+
+                            if (activity != null){
+                                activity.didFinishLoading(); //Notifiy activity that loading is done
+                            }
                         } else {
                             Log.e("PostManager", "Json Exception: ", e);
                         }
                     }
                 });
     }
+
 
     /**
      * Assigns a feedAdapter to the PostManager

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -6,7 +6,6 @@ import com.google.gson.*;
 import com.google.gson.reflect.TypeToken;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
-import nl.fhict.happynews.android.activity.MainActivity;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
 import nl.fhict.happynews.android.model.Page;
 
@@ -49,7 +48,7 @@ public class PostManager {
 
         Ion.getDefault(context).configure().setGson(gson);
         Ion.with(context)
-                .load(API_URL + "/postpage?page=" + page + "&size=" + size)
+                .load(API_URL + "/post?page=" + page + "&size=" + size)
                 .as(new TypeToken<Page>() {
                 })
                 .setCallback(new FutureCallback<Page>() {

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -24,7 +24,7 @@ public class PostManager {
     }
     private static final String API_URL = "https://happynews-api.svendubbeld.nl";
     private FeedAdapter feedAdapter;
-    private MainActivity mainActivity;
+    private LoadListener listener;
 
     private PostManager() {}
 
@@ -34,7 +34,7 @@ public class PostManager {
      * @param size
      * @param context
      */
-    public void loadPage(int page, int size, Context context){
+    public void loadPage(int page, int size, Context context, final LoadListener listener){
         Ion.with(context);
         GsonBuilder builder = new GsonBuilder();
 
@@ -60,8 +60,8 @@ public class PostManager {
 
                             feedAdapter.addPage(result);
 
-                            if (mainActivity != null){
-                                mainActivity.didFinishLoading(); //Notifiy mainActivity that loading is done
+                            if (listener != null){
+                                listener.onFinishedLoading(); //Notify the listening activity when the loading is finished
                             }
                         } else {
                             Log.e("PostManager", "Json Exception: ", e);
@@ -80,10 +80,10 @@ public class PostManager {
     }
 
     /**
-     * Subscribes an Activity to the PostManager to notify when finished loading
-     * @param activity
+     * Subscribes a LoadListener to the PostManager to notify when finished loading
+     * @param listener
      */
-    public void subscribeActivity(MainActivity activity){
-        this.mainActivity = activity;
+    public void subscribeListener(LoadListener listener){
+        this.listener = listener;
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -36,47 +36,13 @@ public class PostManager {
 
     private PostManager() {}
 
-    public void subscribeActivity(MainActivity activity){
-        this.activity = activity;
-    }
-
     /**
-     * Method that updates the feedAdapter with a new list of posts from the api
-     *
-     * @param context context of the apps
+     * Sends content of a page to the FeedAdapter
+     * @param page
+     * @param size
+     * @param context
      */
-    public void updatePosts(Context context) {
-        Ion.with(context);
-        GsonBuilder builder = new GsonBuilder();
-
-        // Register an adapter to manage the date types as long values
-        builder.registerTypeAdapter(Date.class, new JsonDeserializer<Date>() {
-            public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                return new Date(json.getAsJsonPrimitive().getAsLong());
-            }
-        });
-
-        Gson gson = builder.create();
-
-        Ion.getDefault(context).configure().setGson(gson);
-        Ion.with(context)
-                .load(API_URL + "/post")
-                .as(new TypeToken<List<Post>>() {
-                })
-                .setCallback(new FutureCallback<List<Post>>() {
-                    @Override
-                    public void onCompleted(Exception e, List<Post> posts) {
-                        if (e == null) {
-                            feedAdapter.updateData((ArrayList<Post>) posts);
-                        } else {
-                            Log.e("PostManager", "JSON Exception", e);
-                        }
-                    }
-                });
-    }
-
     public void loadPage(int page, int size, Context context){
-
         Ion.with(context);
         GsonBuilder builder = new GsonBuilder();
 
@@ -91,7 +57,7 @@ public class PostManager {
 
         Ion.getDefault(context).configure().setGson(gson);
         Ion.with(context)
-                .load("http://10.0.2.2:8080/postpage?page=" + page + "&size=" + size)
+                .load(API_URL + "?page=" + page + "&size=" + size)
                 .as(new TypeToken<Page>() {
                 })
                 .setCallback(new FutureCallback<Page>() {
@@ -99,6 +65,7 @@ public class PostManager {
                     public void onCompleted(Exception e, Page result) {
                         if (e == null){
                             Log.d("PostManager", "Loaded page: " + result.getNumber());
+
                             feedAdapter.addPage(result);
 
                             if (activity != null){
@@ -111,7 +78,6 @@ public class PostManager {
                 });
     }
 
-
     /**
      * Assigns a feedAdapter to the PostManager
      *
@@ -119,5 +85,13 @@ public class PostManager {
      */
     public void setFeedAdapter(FeedAdapter feedAdapter) {
         this.feedAdapter = feedAdapter;
+    }
+
+    /**
+     * Subscribes an Activity to the PostManager to notify when finished loading
+     * @param activity
+     */
+    public void subscribeActivity(MainActivity activity){
+        this.activity = activity;
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -7,6 +7,7 @@ import com.google.gson.reflect.TypeToken;
 import com.koushikdutta.async.future.FutureCallback;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
 import com.koushikdutta.ion.Ion;
+import nl.fhict.happynews.android.model.Page;
 import nl.fhict.happynews.android.model.Post;
 
 import java.lang.reflect.Type;
@@ -61,6 +62,38 @@ public class PostManager {
                             feedAdapter.updateData((ArrayList<Post>) posts);
                         } else {
                             Log.e("PostManager", "JSON Exception", e);
+                        }
+                    }
+                });
+    }
+
+    public void loadPage(int page, int size, Context context){
+
+        Ion.with(context);
+        GsonBuilder builder = new GsonBuilder();
+
+        // Register an adapter to manage the date types as long values
+        builder.registerTypeAdapter(Date.class, new JsonDeserializer<Date>() {
+            public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                return new Date(json.getAsJsonPrimitive().getAsLong());
+            }
+        });
+
+        Gson gson = builder.create();
+
+        Ion.getDefault(context).configure().setGson(gson);
+        Ion.with(context)
+                .load("http://10.0.2.2:8080/page?page=" + page + "&size=" + size)
+                .as(new TypeToken<Page>() {
+                })
+                .setCallback(new FutureCallback<Page>() {
+                    @Override
+                    public void onCompleted(Exception e, Page result) {
+                        if (e == null){
+                            //DO SOME SHIT
+                            feedAdapter.addPage(result);
+                        } else {
+                            Log.e("PostManager", "Json Exception: ", e);
                         }
                     }
                 });

--- a/android/src/main/java/nl/fhict/happynews/android/PostManager.java
+++ b/android/src/main/java/nl/fhict/happynews/android/PostManager.java
@@ -28,8 +28,7 @@ public class PostManager {
         return ourInstance;
     }
 
-    private String API_URL = "https://happynews-api.svendubbeld.nl/";
-    private ArrayList<Post> newPosts;
+    private String API_URL = "https://happynews-api.svendubbeld.nl";
     private FeedAdapter feedAdapter;
 
     private MainActivity activity;
@@ -57,7 +56,7 @@ public class PostManager {
 
         Ion.getDefault(context).configure().setGson(gson);
         Ion.with(context)
-                .load(API_URL + "?page=" + page + "&size=" + size)
+                .load(API_URL + "/postpage?page=" + page + "&size=" + size)
                 .as(new TypeToken<Page>() {
                 })
                 .setCallback(new FutureCallback<Page>() {

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -73,6 +73,7 @@ public class MainActivity extends AppCompatActivity implements LoadListener{
      * this notification will be called when content
      * is finished loading.
      */
+    @Override
     public void onFinishedLoading() {
         loading = false;
     }

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -52,11 +52,7 @@ public class MainActivity extends AppCompatActivity {
                     if (loading) {
                         if ((visibleItemCount + pastVisiblesItems) >= totalItemCount){
                             loading = false;
-
-                            Log.d("RecyclerView", "Reached End");
-
                             Page lastPage = feedAdapter.getLastPage();
-
                             if (!lastPage.isLast()) {
                                 postManager.loadPage(lastPage.getNumber() + 1, 20, getApplicationContext());
                             }
@@ -67,6 +63,12 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
+
+    /**
+     * When this activity is subscribed to a PostManager,
+     * this notification will be called when content
+     * is finished loading.
+     */
     public void didFinishLoading() {
         loading = true;
     }

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -31,7 +31,6 @@ public class MainActivity extends AppCompatActivity implements LoadListener{
         setContentView(R.layout.activity_main);
 
         postManager = PostManager.getInstance();
-        postManager.subscribeListener(this);
 
         recyclerView = (RecyclerView) findViewById(R.id.recyclerView);
         feedAdapter = new FeedAdapter(this, new ArrayList<Post>());

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -33,6 +33,6 @@ public class MainActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(layoutManager);
 
         postManager.setFeedAdapter(feedAdapter);
-        postManager.updatePosts(this);
+        postManager.loadPage(0, 20, this);
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -1,15 +1,14 @@
 package nl.fhict.happynews.android.activity;
 
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
+import nl.fhict.happynews.android.PostManager;
+import nl.fhict.happynews.android.R;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
 import nl.fhict.happynews.android.model.Page;
 import nl.fhict.happynews.android.model.Post;
-import nl.fhict.happynews.android.PostManager;
-import nl.fhict.happynews.android.R;
 
 import java.util.ArrayList;
 
@@ -41,6 +40,10 @@ public class MainActivity extends AppCompatActivity {
         postManager.setFeedAdapter(feedAdapter);
         postManager.loadPage(0, 20, this);
 
+        addScrollListener();
+    }
+
+    private void addScrollListener(){
         recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
@@ -62,7 +65,6 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
-
 
     /**
      * When this activity is subscribed to a PostManager,

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -20,8 +20,9 @@ public class MainActivity extends AppCompatActivity {
     private LinearLayoutManager layoutManager;
     private FeedAdapter feedAdapter;
 
-    private boolean loading = true;
+    private boolean loading;
     int pastVisiblesItems, visibleItemCount, totalItemCount;
+    private static final int PAGE_SIZE = 20;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,7 +39,8 @@ public class MainActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(layoutManager);
 
         postManager.setFeedAdapter(feedAdapter);
-        postManager.loadPage(0, 20, this);
+        postManager.loadPage(0, PAGE_SIZE, this);
+        loading = true;
 
         addScrollListener();
     }
@@ -57,7 +59,7 @@ public class MainActivity extends AppCompatActivity {
                             loading = false;
                             Page lastPage = feedAdapter.getLastPage();
                             if (!lastPage.isLast()) {
-                                postManager.loadPage(lastPage.getNumber() + 1, 20, getApplicationContext());
+                                postManager.loadPage(lastPage.getNumber() + 1, PAGE_SIZE, getApplicationContext());
                             }
                         }
                     }

--- a/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
+++ b/android/src/main/java/nl/fhict/happynews/android/activity/MainActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import nl.fhict.happynews.android.LoadListener;
 import nl.fhict.happynews.android.PostManager;
 import nl.fhict.happynews.android.R;
 import nl.fhict.happynews.android.adapter.FeedAdapter;
@@ -13,7 +14,7 @@ import nl.fhict.happynews.android.model.Post;
 import java.util.ArrayList;
 
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements LoadListener{
 
     private PostManager postManager;
     private RecyclerView recyclerView;
@@ -30,7 +31,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         postManager = PostManager.getInstance();
-        postManager.subscribeActivity(this);
+        postManager.subscribeListener(this);
 
         recyclerView = (RecyclerView) findViewById(R.id.recyclerView);
         feedAdapter = new FeedAdapter(this, new ArrayList<Post>());
@@ -39,7 +40,7 @@ public class MainActivity extends AppCompatActivity {
         recyclerView.setLayoutManager(layoutManager);
 
         postManager.setFeedAdapter(feedAdapter);
-        postManager.loadPage(0, PAGE_SIZE, this);
+        postManager.loadPage(0, PAGE_SIZE, this, this);
         loading = true;
 
         addScrollListener();
@@ -54,12 +55,12 @@ public class MainActivity extends AppCompatActivity {
                     totalItemCount = layoutManager.getItemCount();
                     pastVisiblesItems = layoutManager.findFirstVisibleItemPosition();
 
-                    if (loading) {
+                    if (!loading) {
                         if ((visibleItemCount + pastVisiblesItems) >= totalItemCount){
-                            loading = false;
+                            loading = true;
                             Page lastPage = feedAdapter.getLastPage();
                             if (!lastPage.isLast()) {
-                                postManager.loadPage(lastPage.getNumber() + 1, PAGE_SIZE, getApplicationContext());
+                                postManager.loadPage(lastPage.getNumber() + 1, PAGE_SIZE, getApplicationContext(), MainActivity.this);
                             }
                         }
                     }
@@ -73,7 +74,7 @@ public class MainActivity extends AppCompatActivity {
      * this notification will be called when content
      * is finished loading.
      */
-    public void didFinishLoading() {
-        loading = true;
+    public void onFinishedLoading() {
+        loading = false;
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
+++ b/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import nl.fhict.happynews.android.model.Page;
 import nl.fhict.happynews.android.model.Post;
 import nl.fhict.happynews.android.R;
 import nl.fhict.happynews.android.viewholder.PostHolder;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     private final Context mContext;
+    private Page lastPage;
     private ArrayList<Post> posts;
 
     public FeedAdapter(Context mContext, ArrayList<Post> posts) {
@@ -94,6 +96,14 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             this.posts = posts;
             this.notifyDataSetChanged();
             Log.d("FeedAdapter", "Updated Data");
+        }
+    }
+
+    public void addPage(Page page) {
+        if (page != null) {
+            this.lastPage = page;
+            this.posts.addAll(page.getContent());
+            this.notifyDataSetChanged();
         }
     }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
+++ b/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
@@ -84,21 +84,11 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         return posts.size();
     }
 
-    /**
-     * Change the current list of posts with a new list of posts
-     * keeps the old list if the new list is null
-     * notifies the adapter to show the changes in the app
-     *
-     * @param posts
-     */
-    public void updateData(ArrayList<Post> posts) {
-        if (posts != null) {
-            this.posts = posts;
-            this.notifyDataSetChanged();
-            Log.d("FeedAdapter", "Updated Data");
-        }
-    }
 
+    /**
+     * Adds the content of a page to the current list of posts
+     * @param page the loaded page element
+     */
     public void addPage(Page page) {
         if (page != null) {
             this.lastPage = page;

--- a/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
+++ b/android/src/main/java/nl/fhict/happynews/android/adapter/FeedAdapter.java
@@ -106,4 +106,8 @@ public class FeedAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             this.notifyDataSetChanged();
         }
     }
+
+    public Page getLastPage() {
+        return lastPage;
+    }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/model/Page.java
+++ b/android/src/main/java/nl/fhict/happynews/android/model/Page.java
@@ -1,0 +1,26 @@
+package nl.fhict.happynews.android.model;
+
+import java.util.ArrayList;
+
+/**
+ * Created by tom on 03/04/2017.
+ */
+public class Page {
+
+    ArrayList<Post> content;
+    boolean first;
+    boolean last;
+    int number;
+    int numberOfElements;
+    int size;
+    int totalElements;
+    int totalPages;
+
+    public Page() {
+
+    }
+
+    public ArrayList<Post> getContent() {
+        return content;
+    }
+}

--- a/android/src/main/java/nl/fhict/happynews/android/model/Page.java
+++ b/android/src/main/java/nl/fhict/happynews/android/model/Page.java
@@ -23,4 +23,16 @@ public class Page {
     public ArrayList<Post> getContent() {
         return content;
     }
+
+    public boolean isFirst() {
+        return first;
+    }
+
+    public boolean isLast() {
+        return last;
+    }
+
+    public int getNumber() {
+        return number;
+    }
 }

--- a/android/src/main/java/nl/fhict/happynews/android/model/Page.java
+++ b/android/src/main/java/nl/fhict/happynews/android/model/Page.java
@@ -7,14 +7,9 @@ import java.util.ArrayList;
  */
 public class Page {
 
-    ArrayList<Post> content;
-    boolean first;
-    boolean last;
-    int number;
-    int numberOfElements;
-    int size;
-    int totalElements;
-    int totalPages;
+    private ArrayList<Post> content;
+    private boolean last;
+    private int number;
 
     public Page() {
 
@@ -22,10 +17,6 @@ public class Page {
 
     public ArrayList<Post> getContent() {
         return content;
-    }
-
-    public boolean isFirst() {
-        return first;
     }
 
     public boolean isLast() {

--- a/android/src/main/java/nl/fhict/happynews/android/viewholder/ViewHolder.java
+++ b/android/src/main/java/nl/fhict/happynews/android/viewholder/ViewHolder.java
@@ -36,10 +36,12 @@ public abstract class ViewHolder extends RecyclerView.ViewHolder implements View
      */
     public String relativeTimeSpan(Date input) {
 
-        long unixTime = input.getTime();
+        long unixTime;
 
-        if (unixTime == 0) {
-            return DateUtils.getRelativeTimeSpanString(System.currentTimeMillis()).toString();
+        if (input != null) {
+            unixTime = input.getTime();
+        } else {
+            unixTime = System.currentTimeMillis();
         }
 
         return DateUtils.getRelativeTimeSpanString(unixTime).toString();

--- a/android/src/main/java/nl/fhict/happynews/android/viewholder/ViewHolder.java
+++ b/android/src/main/java/nl/fhict/happynews/android/viewholder/ViewHolder.java
@@ -35,7 +35,6 @@ public abstract class ViewHolder extends RecyclerView.ViewHolder implements View
      * @return relative Timestamp (eg. '4 hours ago')
      */
     public String relativeTimeSpan(Date input) {
-
         long unixTime;
 
         if (input != null) {

--- a/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
+++ b/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
@@ -1,18 +1,18 @@
 package nl.fhict.happynews.api.controller;
 
+import com.sun.org.apache.regexp.internal.RE;
 import nl.fhict.happynews.api.hibernate.PostRepository;
 import nl.fhict.happynews.shared.Post;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
+import java.util.*;
 
 /**
  * Created by Tobi on 06-Mar-17.
@@ -36,6 +36,11 @@ public class PostController {
         }else{
             return this.postRepository.findAll();
         }
+    }
+
+    @RequestMapping(value = "/page", method = RequestMethod.GET, produces = "application/json")
+    public Page<Post> getAllByPage(Pageable pageable){
+        return this.postRepository.findAll(pageable);
     }
 
     /**

--- a/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
+++ b/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
@@ -38,6 +38,12 @@ public class PostController {
         }
     }
 
+
+    /**
+     * Handles a GET request by returning posts in a paginated format.
+     * @param pageable the page and page size
+     * @return A Page with Post information
+     */
     @RequestMapping(value = "/page", method = RequestMethod.GET, produces = "application/json")
     public Page<Post> getAllByPage(Pageable pageable){
         return this.postRepository.findAll(pageable);

--- a/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
+++ b/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
@@ -44,9 +44,9 @@ public class PostController {
      * @param pageable the page and page size
      * @return A Page with Post information
      */
-    @RequestMapping(value = "/page", method = RequestMethod.GET, produces = "application/json")
+    @RequestMapping(value = "/postpage", method = RequestMethod.GET, produces = "application/json")
     public Page<Post> getAllByPage(Pageable pageable){
-        return this.postRepository.findAll(pageable);
+        return this.postRepository.findAllByOrderByPublishedAtDesc(pageable);
     }
 
     /**

--- a/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
+++ b/api/src/main/java/nl/fhict/happynews/api/controller/PostController.java
@@ -25,26 +25,11 @@ public class PostController {
     private PostRepository postRepository;
 
     /**
-     * Handles a GET request by returning all posts.
-     * @param ordered Whether the list should be ordered by latest or not.
-     * @return The Posts in JSON.
-     */
-    @RequestMapping(value = "/post", method = RequestMethod.GET, produces = "application/json")
-    public Collection<Post> getAllPost(@RequestParam(required = false, defaultValue = "true", value="ordered") boolean ordered) {
-        if(ordered){
-            return this.postRepository.findAllByOrderByPublishedAtDesc();
-        }else{
-            return this.postRepository.findAll();
-        }
-    }
-
-
-    /**
-     * Handles a GET request by returning posts in a paginated format.
+     * Handles a GET request by returning posts in a paginated format. Default page is 0, and default size = 20
      * @param pageable the page and page size
      * @return A Page with Post information
      */
-    @RequestMapping(value = "/postpage", method = RequestMethod.GET, produces = "application/json")
+    @RequestMapping(value = "/post", method = RequestMethod.GET, produces = "application/json")
     public Page<Post> getAllByPage(Pageable pageable){
         return this.postRepository.findAllByOrderByPublishedAtDesc(pageable);
     }

--- a/api/src/main/java/nl/fhict/happynews/api/hibernate/PostRepository.java
+++ b/api/src/main/java/nl/fhict/happynews/api/hibernate/PostRepository.java
@@ -1,21 +1,22 @@
 package nl.fhict.happynews.api.hibernate;
 
 import nl.fhict.happynews.shared.Post;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Created by Tobi on 06-Mar-17.
  */
-public interface PostRepository extends CrudRepository<Post, String> {
+public interface PostRepository extends MongoRepository<Post, String> {
 
     /**
      * Retrieves all Posts.
      * @return A collection of posts.
      */
-    Collection<Post> findAll();
+    List<Post> findAll();
 
     /**
      * Retrieves all Posts, ordered by publish date.

--- a/api/src/main/java/nl/fhict/happynews/api/hibernate/PostRepository.java
+++ b/api/src/main/java/nl/fhict/happynews/api/hibernate/PostRepository.java
@@ -1,6 +1,8 @@
 package nl.fhict.happynews.api.hibernate;
 
 import nl.fhict.happynews.shared.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Collection;
@@ -23,6 +25,13 @@ public interface PostRepository extends MongoRepository<Post, String> {
      * @return A collection of posts.
      */
     Collection<Post> findAllByOrderByPublishedAtDesc();
+
+    /**
+     * Retrieves all Posts, ordered by publish date, in a Page format
+     * @param pageable
+     * @return A page with post content
+     */
+    Page<Post> findAllByOrderByPublishedAtDesc(Pageable pageable);
 
     /**
      * Retrieves a Post by it's UUID.

--- a/api/src/test/java/nl/fhict/happynews/api/controller/PostControllerTest.java
+++ b/api/src/test/java/nl/fhict/happynews/api/controller/PostControllerTest.java
@@ -118,16 +118,8 @@ public class PostControllerTest {
         //regular get all posts
         this.mockMvc.perform(get("/post"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(5)))
-                .andExpect(jsonPath("$[0].sourceName", is("De Tilburger")));
-        //superfluous ordered parameter
-        this.mockMvc.perform(get("/post?ordered={ordered}", true))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].sourceName", is("De Tilburger")));
-        //unordered list
-        this.mockMvc.perform(get("/post?ordered={ordered}", false))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[1].sourceName", is("The Post")));
+                .andExpect(jsonPath("$.content", hasSize(5)));
+
     }
 
     @Test


### PR DESCRIPTION
In this PR i've added paging to the API and continuous scrolling in the android client.

- Paged results are accessible via api endpoint `/postpage`. This takes two URL parameters `page` and `size`. Results are automatically sorted on publication date.
- The android application uses Ion to load the page as a Page object. The posts are contained in an ArrayList called content.
- The FeedAdapter has a method called `addPage(Page page)` which adds the content of the page to the feed, and saves the page as `lastPage` to hold the position in the feed.

---

Before submitting your pull request, consider the following: Does your code...

- [x] Implement functionality
- [x] Contain comments/documentation
- [x] Build without errors
- [x] Contain and pass unit testing
- [x] Conform to the Style Guide
- [x] Have no merge conflicts with ```master```

When you've checked all of the boxes above your code is up for review. If approved it can be merged with the ```master``` branch.

If you want feedback on your work before having finished your code, add ```[WIP]``` to the title of your PR.